### PR TITLE
Add deprecation notice in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# [DEPRECATED] This project is deprecated in favor of [the @noflux project](https://github.com/nofluxjs/noflux)
+
+* A migration document can be found [here](https://noflux.js.org/en/advanced/migration.html).
+
+* 迁移文档请见[这里](https://noflux.js.org/zh/advanced/migration.html)。
+
+---
+
 [![Build Status](https://travis-ci.org/ssnau/noflux.svg?branch=master)](https://travis-ci.org/ssnau/noflux)
 
 noflux

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jsdom": "^5.4.3",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "0.0.2",
-    "react": ">0.10",
+    "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.3",
     "sinon": "^1.14.1"
   },


### PR DESCRIPTION
```bash
npm deprecate noflux@"<=2.2.3" '`noflux` is deprecated in favor of `@noflux/react`. See more detail https://noflux.js.org/en/advanced/migration.html'
```